### PR TITLE
Disable Expect: 100-continue in the php introspection endpoint

### DIFF
--- a/introspect.php
+++ b/introspect.php
@@ -22,7 +22,7 @@ curl_setopt_array($curl, array(
   CURLOPT_POSTFIELDS => 'access_token='.$access_token.'&token_type_hint=access_token',
   CURLOPT_HTTPHEADER => array(
     'Content-Type: application/x-www-form-urlencoded',
-    // Disable Expect: 100-continue since it's not supported by the google tokeninfo endpoint.
+    // Disable Expect: 100-continue to reduce latency to the google tokeninfo endpoint.
     'Expect:'
   ),
 ));

--- a/introspect.php
+++ b/introspect.php
@@ -21,7 +21,9 @@ curl_setopt_array($curl, array(
   CURLOPT_CUSTOMREQUEST => 'POST',
   CURLOPT_POSTFIELDS => 'access_token='.$access_token.'&token_type_hint=access_token',
   CURLOPT_HTTPHEADER => array(
-    'Content-Type: application/x-www-form-urlencoded'
+    'Content-Type: application/x-www-form-urlencoded',
+    // Disable Expect: 100-continue since it's not supported by the google tokeninfo endpoint.
+    'Expect:'
   ),
 ));
 


### PR DESCRIPTION
While re-testing this, I see an added ~1s latency in the POST request to `https://www.googleapis.com/oauth2/v3/tokeninfo`. Seeing if this fixes it (related to https://docs.google.com/document/d/1ZV-meiMt2F3tsgifXCaTrGBLFTyBN1tNKU-nFwSk-lE/edit).