### PR TITLE
Add image based on RedHat ubi-minimal

### DIFF
--- a/.github/workflows/push_redhat.yaml
+++ b/.github/workflows/push_redhat.yaml
@@ -1,0 +1,86 @@
+name: Bump, Tag, and Publish RedHat
+# The purpose of the workflow is to:
+#  1. Bump the version number and tag the release if not a PR
+#  2. Build docker image and publish to GCR
+#
+# When run on merge to main, it tags and bumps the patch version by default. You can
+# bump other parts of the version by putting #major, #minor, or #patch in your commit
+# message.
+#
+# When run on a PR, it simulates bumping the tag and appends a hash to the pushed image.
+#
+# The workflow relies on github secrets:
+# - GCR_PUBLISH_EMAIL - SA email for publishing to broad-dsp-gcr-public
+# - GCR_PUBLISH_KEY_B64 - SA key (Base64-encoded JSON string) for publishing to broad-dsp-gcr-public
+# - BROADBOT_TOKEN - the broadbot token, so we can avoid two reviewer rule on GHA operations
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+env:
+  # The Google project, which is also the name of the repository for GCR
+  GOOGLE_PROJECT: broad-dsp-gcr-public
+  # Name of the image to make in the GOOGLE_PROJECT repository
+  IMAGE_NAME: httpd-terra-proxy
+  # Google Docker repository where the GOOGLE_PROJECT repository can be found
+  GOOGLE_DOCKER_REPOSITORY: us.gcr.io
+jobs:
+  tag-publish-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Bump the tag to a new version
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+        id: tag
+        env:
+          DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          RELEASE_BRANCHES: main
+          WITH_V: true
+
+      - name: Auth to GCP
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '345.0.0'
+          service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
+          service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+
+      - name: Explicitly auth Docker for GCR
+        run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet
+
+      - name: Construct docker image name and tag
+        id: image-name
+        run: |
+          DOCKER_TAG=${{ steps.tag.outputs.tag }}
+          echo ::set-output name=name::${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${IMAGE_NAME}:${DOCKER_TAG}
+
+      - name: Build image
+        run: "docker build -f Dockerfile.ubi-minimal -t ${{ steps.image-name.outputs.name }} ."
+
+      - name: Run Trivy vulnerability scanner
+        # From https://github.com/broadinstitute/dsp-appsec-trivy-action
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.image-name.outputs.name }}
+
+      - name: Push image
+        run: "docker push ${{ steps.image-name.outputs.name }}"
+
+      - name: Comment pushed image
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: 'Pushed image: ${{ steps.image-name.outputs.name }}' });
+  

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -52,4 +52,9 @@ RUN chmod a+x /usr/bin/run-httpd \
   && sed -i 's/\/run\/php\/php7\.2-fpm\.sock/\/run\/php-fpm\/www.sock/g' /etc/php-fpm.d/www.conf \
   && rm -rf /tmp/build
 
+EXPOSE 8080
+EXPOSE 8443
+EXPOSE 80
+EXPOSE 443
+
 CMD php-fpm & /usr/bin/run-httpd

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -52,8 +52,6 @@ RUN chmod a+x /usr/bin/run-httpd \
   && sed -i 's/\/run\/php\/php7\.2-fpm\.sock/\/run\/php-fpm\/www.sock/g' /etc/php-fpm.d/www.conf \
   && rm -rf /tmp/build
 
-EXPOSE 8080
-EXPOSE 8443
 EXPOSE 80
 EXPOSE 443
 

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -1,0 +1,55 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ENV LIBOAUTH2_VERSION=1.4.4.1 \
+    OAUTH2_VERSION=3.2.2
+
+# Install dependencies
+RUN microdnf --nodocs -y install \
+  httpd \
+  php \
+  procps \
+  wget \
+  tar \
+  openssl \
+  jansson \
+  libmemcached \
+  mod_ssl \
+  mod_ldap \
+  && microdnf clean all
+
+# Install hiredis (dependency of liboauth2) from EPEL
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+  && microdnf --nodocs -y install \
+    hiredis-0.13.3-13.el8.x86_64 \
+  && microdnf clean all
+
+# Install tcell module
+RUN mkdir -p /tmp/build && cd /tmp/build \
+   && wget https://us.static.tcell.insight.rapid7.com/downloads/apacheagent/apache24_tcellagent-3.1.0-linux-x86_64.tgz \ 
+   && tar -xzf apache24_tcellagent-3.1.0-linux-x86_64.tgz \
+   && cp -rfp apache_tcellagent-3.1.0-linux-x86_64/centos/mod_agenttcell.so /etc/httpd/modules/mod_agenttcell.so
+
+# Install mod_oauth2 module
+RUN rpm -ivh \
+  https://mod-auth-openidc.org/download/cjose-0.6.1.5-2.el8.x86_64.rpm \
+  https://github.com/zmartzone/liboauth2/releases/download/v${LIBOAUTH2_VERSION}/liboauth2-${LIBOAUTH2_VERSION}-1.el8.x86_64.rpm \
+  https://github.com/zmartzone/liboauth2/releases/download/v${LIBOAUTH2_VERSION}/liboauth2-apache-${LIBOAUTH2_VERSION}-1.el8.x86_64.rpm \
+  https://github.com/zmartzone/mod_oauth2/releases/download/v${OAUTH2_VERSION}/mod_oauth2-${OAUTH2_VERSION}-1.el8.x86_64.rpm
+
+# Copy configs
+COPY site.conf stackdriver.conf mpm_event.conf oauth2.conf ssl_fips.conf /etc/httpd/conf.d/
+COPY introspect.php /app/introspect/index.php
+COPY run-httpd /usr/bin
+COPY www.conf /etc/php-fpm.d/www.conf
+COPY setup-httpd.sh /tmp/build/setup-httpd.sh
+
+# Setup httpd and php-fpm
+RUN chmod a+x /usr/bin/run-httpd \
+  && chmod a+x /tmp/build/setup-httpd.sh \
+  && /tmp/build/setup-httpd.sh \
+  && mkdir -p /run/php-fpm \
+  && sed -i 's/www-data/apache/g' /etc/php-fpm.d/www.conf \
+  && sed -i 's/\/run\/php\/php7\.2-fpm\.sock/\/run\/php-fpm\/www.sock/g' /etc/php-fpm.d/www.conf \
+  && rm -rf /tmp/build
+
+CMD php-fpm & /usr/bin/run-httpd

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -7,6 +7,7 @@ ENV LIBOAUTH2_VERSION=1.4.4.1 \
 RUN microdnf --nodocs -y install \
   httpd \
   php \
+  php-curl \
   procps \
   wget \
   tar \

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -7,6 +7,7 @@ ENV LIBOAUTH2_VERSION=1.4.4.1 \
 RUN microdnf --nodocs -y install \
   httpd \
   php \
+  php-json \
   php-curl \
   procps \
   wget \

--- a/oauth2.conf
+++ b/oauth2.conf
@@ -1,2 +1,2 @@
 # See https://raw.githubusercontent.com/zmartzone/mod_oauth2/master/oauth2.conf for more examples
-OAuth2TokenVerify introspect http://127.0.0.1/introspect/ introspect.ssl_verify=false&verify.iat=skip
+OAuth2TokenVerify introspect http://127.0.0.1/introspect/ introspect.ssl_verify=false&verify.exp=required&verify.iat=skip

--- a/run-httpd
+++ b/run-httpd
@@ -1,0 +1,225 @@
+#!/bin/bash
+
+set -e
+
+export LANG=C
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export TZ=America/New_York
+
+# update SERVER_ADMIN
+if [ -z "$SERVER_ADMIN" ] ; then
+    export SERVER_ADMIN=webmaster@example.org
+fi
+
+# update SERVER_NAME
+if [ -z "$SERVER_NAME" ] ; then
+    export SERVER_NAME=localhost
+fi
+
+# update PROXY_PATH
+if [ -z "$PROXY_PATH" ] ; then
+    export PROXY_PATH=/
+fi
+
+# update PROXY_PATH2
+if [ -z "$PROXY_PATH2" ] ; then
+    export PROXY_PATH2=/api
+fi
+
+# update PROXY_PATH3
+if [ -z "$PROXY_PATH3" ] ; then
+    export PROXY_PATH3=/register
+fi
+
+# update PROXY_URL
+if [ -z "$PROXY_URL" ] ; then
+    export PROXY_URL=http://app:8080/
+fi
+
+# update PROXY_URL2
+if [ -z "$PROXY_URL2" ] ; then
+    export PROXY_URL2=http://app:8080/api
+fi
+
+# update PROXY_URL3
+if [ -z "$PROXY_URL3" ] ; then
+    export PROXY_URL3=http://app:8080/register
+fi
+
+# update FILTER
+if [ -z "$FILTER" ] ; then
+    export FILTER=
+fi
+
+# update FILTER2
+if [ -z "$FILTER2" ] ; then
+    export FILTER2=
+fi
+
+# update FILTER3
+if [ -z "$FILTER3" ] ; then
+    export FILTER3=
+fi
+
+# update AUTH_REQUIRE
+if [ -z "$AUTH_REQUIRE" ] ; then
+    export AUTH_REQUIRE='Require all granted'
+elif [ "$AUTH_REQUIRE" = '(none)' ]; then
+    export AUTH_REQUIRE=
+fi
+
+# update AUTH_REQUIRE2
+if [ -z "$AUTH_REQUIRE2" ] ; then
+    export AUTH_REQUIRE2='Require valid-user'
+elif [ "$AUTH_REQUIRE2" = '(none)' ]; then
+    export AUTH_REQUIRE2=
+fi
+
+# update AUTH_REQUIRE3
+if [ -z "$AUTH_REQUIRE3" ] ; then
+    export AUTH_REQUIRE3='Require valid-user'
+elif [ "$AUTH_REQUIRE3" = '(none)' ]; then
+    export AUTH_REQUIRE3=
+fi
+
+# update AUTH_TYPE
+if [ -z "$AUTH_TYPE" ] ; then
+    export AUTH_TYPE='AuthType None'
+fi
+
+# update AUTH_TYPE2
+if [ -z "$AUTH_TYPE2" ] ; then
+    export AUTH_TYPE2='AuthType oauth2'
+fi
+
+# update AUTH_TYPE3
+if [ -z "$AUTH_TYPE3" ] ; then
+    export AUTH_TYPE3='AuthType oauth2'
+fi
+
+# update AUTH_LDAP_BIND_DN
+if [ -z "$AUTH_LDAP_BIND_DN" ] ; then
+    export AUTH_LDAP_BIND_DN=
+fi
+
+# update AUTH_LDAP_BIND_DN2
+if [ -z "$AUTH_LDAP_BIND_DN2" ] ; then
+    export AUTH_LDAP_BIND_DN2=
+fi
+
+# update AUTH_LDAP_BIND_DN3
+if [ -z "$AUTH_LDAP_BIND_DN3" ] ; then
+    export AUTH_LDAP_BIND_DN3=
+fi
+
+# update AUTH_LDAP_BIND_PASSWORD
+if [ -z "$AUTH_LDAP_BIND_PASSWORD" ] ; then
+    export AUTH_LDAP_BIND_PASSWORD=
+fi
+
+# update AUTH_LDAP_BIND_PASSWORD2
+if [ -z "$AUTH_LDAP_BIND_PASSWORD2" ] ; then
+    export AUTH_LDAP_BIND_PASSWORD2=
+fi
+
+# update AUTH_LDAP_BIND_PASSWORD3
+if [ -z "$AUTH_LDAP_BIND_PASSWORD3" ] ; then
+    export AUTH_LDAP_BIND_PASSWORD3=
+fi
+
+# update AUTH_LDAP_URL
+if [ -z "$AUTH_LDAP_URL" ] ; then
+    export AUTH_LDAP_URL=
+fi
+
+# update AUTH_LDAP_URL2
+if [ -z "$AUTH_LDAP_URL2" ] ; then
+    export AUTH_LDAP_URL2=
+fi
+
+# update AUTH_LDAP_URL3
+if [ -z "$AUTH_LDAP_URL3" ] ; then
+    export AUTH_LDAP_URL3=
+fi
+
+# update AUTH_LDAP_GROUP_ATTR
+if [ -z "$AUTH_LDAP_GROUP_ATTR" ] ; then
+    export AUTH_LDAP_GROUP_ATTR=
+fi
+
+# update AUTH_LDAP_GROUP_ATTR2
+if [ -z "$AUTH_LDAP_GROUP_ATTR2" ] ; then
+    export AUTH_LDAP_GROUP_ATTR2=
+fi
+
+# update AUTH_LDAP_GROUP_ATTR3
+if [ -z "$AUTH_LDAP_GROUP_ATTR3" ] ; then
+    export AUTH_LDAP_GROUP_ATTR3=
+fi
+
+# update LDAP_CACHE_TTL
+if [ -z "$LDAP_CACHE_TTL" ] ; then
+    export LDAP_CACHE_TTL='60'
+fi
+
+# update CALLBACK_URI
+if [ -z "$CALLBACK_URI" ] ; then
+    export CALLBACK_URI="https://${SERVER_NAME}/oauth2callback"
+fi
+
+# update CALLBACK_PATH
+if [ -z "$CALLBACK_PATH" ] ; then
+    # shellcheck disable=SC2006
+    CALLBACK_PATH=/`echo $CALLBACK_URI | rev | cut -d/ -f1 | rev`
+    export CALLBACK_PATH
+fi
+
+# update INTROSPECT_PATH
+if [ -z "$INTROSPECT_PATH" ] ; then
+    export INTROSPECT_PATH='/introspect/'
+fi
+
+# set httpd port
+if [ -z "$HTTPD_PORT" ] ; then
+    export HTTPD_PORT=80
+fi
+
+# set httpd ssl port
+if [ -z "$SSL_HTTPD_PORT" ] ; then
+    export SSL_HTTPD_PORT=443
+fi
+
+# update LOG_LEVEL
+if [ -z "$LOG_LEVEL" ] ; then
+    export LOG_LEVEL=warn
+fi
+
+# update PROXY_TIMEOUT
+if [ -z "$PROXY_TIMEOUT" ] ; then
+    export PROXY_TIMEOUT='300'
+fi
+
+# update ENVIRONMENT
+if [ -z "$ENVIRONMENT" ] ; then
+    export ENVIRONMENT='dev'
+fi
+
+# update ALLOW_EXPRESSION
+if [ -z "$ALLOW_EXPRESSION" ] ; then
+    export ALLOW_EXPRESSION='true'
+fi
+
+# set SSL protocol
+if [ -z "$SSL_PROTOCOL" ] ; then
+    export SSL_PROTOCOL='-SSLv3 -TLSv1 -TLSv1.1 +TLSv1.2'
+fi
+
+# set the SSL Cipher Suite
+if [ -z "$SSL_CIPHER_SUITE" ] ; then
+    export SSL_CIPHER_SUITE='ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-ES256-SHA:!3DES:!ADH:!DES:!DH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!EXPORT:!KRB5-DES-CBC3-SHA:!MD5:!PSK:!RC4:!aECDH:!aNULL:!eNULL'
+fi
+
+# Apache gets grumpy about PID files pre-existing
+rm -f /var/run/httpd/httpd.pid
+
+exec httpd -D FOREGROUND $@

--- a/setup-httpd.sh
+++ b/setup-httpd.sh
@@ -13,7 +13,7 @@ openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
     -out /etc/ssl/certs/server.crt
 
 # Use the snakeoil cert as the ca-bundle.crt as well
-cat /etc/ssl/certs/server.crt >> /etc/ssl/certs/ca-bundle.crt
+cp /etc/ssl/certs/server.crt /etc/ssl/certs/server-ca-bundle.crt
 
 # Remove default ssl.conf
 rm /etc/httpd/conf.d/ssl.conf

--- a/setup-httpd.sh
+++ b/setup-httpd.sh
@@ -4,13 +4,16 @@ set -e
 
 echo "Setting up http environment"
 
-mkdir -p /etc/ssl/private
+ln -s /etc/pki/tls/private /etc/ssl/private
 
 # Generate a snakeoil certificate in case it's needed
 openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
     -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Random Bits/OU=Widgets/CN=localhost/emailAddress=webmaster@example.org" \
     -keyout /etc/ssl/private/server.key \
     -out /etc/ssl/certs/server.crt
+
+# Use the snakeoil cert as the ca-bundle.crt as well
+cat /etc/ssl/certs/server.crt >> /etc/ssl/certs/ca-bundle.crt
 
 # Remove default ssl.conf
 rm /etc/httpd/conf.d/ssl.conf

--- a/setup-httpd.sh
+++ b/setup-httpd.sh
@@ -12,8 +12,5 @@ openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
     -keyout /etc/ssl/private/server.key \
     -out /etc/ssl/certs/server.crt
 
-# Use the snakeoil cert as the ca-bundle.crt as well
-cp /etc/ssl/certs/server.crt /etc/ssl/certs/ca-bundle.crt
-
 # Remove default ssl.conf
 rm /etc/httpd/conf.d/ssl.conf

--- a/setup-httpd.sh
+++ b/setup-httpd.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo "Setting up http environment"
+
+mkdir -p /etc/ssl/private
+
+# Generate a snakeoil certificate in case it's needed
+openssl req -newkey rsa:4096 -days 365 -nodes -x509 \
+    -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Random Bits/OU=Widgets/CN=localhost/emailAddress=webmaster@example.org" \
+    -keyout /etc/ssl/private/server.key \
+    -out /etc/ssl/certs/server.crt
+
+# Use the snakeoil cert as the ca-bundle.crt as well
+cp /etc/ssl/certs/server.crt /etc/ssl/certs/ca-bundle.crt
+
+# Remove default ssl.conf
+rm /etc/httpd/conf.d/ssl.conf

--- a/site.conf
+++ b/site.conf
@@ -14,7 +14,6 @@ LDAPCacheTTL ${LDAP_CACHE_TTL}
 LDAPRetries 5
 LDAPRetryDelay 1
 LDAPConnectionPoolTTL 30
-OIDCOAuthTokenIntrospectionInterval 60
 
 AddType application/x-httpd-php .php
 

--- a/site.conf
+++ b/site.conf
@@ -23,6 +23,8 @@ AddType application/x-httpd-php .php
     Redirect 307 / https://${SERVER_NAME}/
 </VirtualHost>
 
+Listen 0.0.0.0:${SSL_HTTPD_PORT}
+
 <VirtualHost _default_:${SSL_HTTPD_PORT}>
 
     DocumentRoot /app

--- a/site.conf
+++ b/site.conf
@@ -46,7 +46,7 @@ Listen 0.0.0.0:${SSL_HTTPD_PORT}
     SSLCipherSuite ${SSL_CIPHER_SUITE}
     SSLCertificateFile "/etc/ssl/certs/server.crt"
     SSLCertificateKeyFile "/etc/ssl/private/server.key"
-    SSLCertificateChainFile "/etc/ssl/certs/ca-bundle.crt"
+    SSLCertificateChainFile "/etc/ssl/certs/server-ca-bundle.crt"
 
     <Location ${INTROSPECT_PATH}>
         RewriteEngine off

--- a/ssl_fips.conf
+++ b/ssl_fips.conf
@@ -1,0 +1,1 @@
+SSLFIPS On


### PR DESCRIPTION
Adds a new `Dockerfile.ubi-minimal` + associated files. This image uses RedHat [ubi-minimal](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#con_understanding-the-ubi-minimal-images_assembly_types-of-container-images) as a base image instead of Ubuntu [phusion](https://github.com/phusion/baseimage-docker).

See discussion in https://docs.google.com/document/d/1l34sAKQPd7t9r2P146EMgXe2WErLuC9DsZBZ3LAtjec/edit#, but the goal is to use a RedHat `ubi` image which supports SSL FIPS verification, as well as has a smaller attack surface.

This works locally - still testing with Terra services.

If we decide to go this route, I am thinking we can remove the unused stuff from this repo related to the Ubuntu image.