### PR TITLE
[no ticket] Add security headers in default site.conf

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,6 +8,16 @@ LogLevel ${LOG_LEVEL}
 
 Header unset X-Frame-Options
 Header always set X-Frame-Options SAMEORIGIN
+Header unset X-XSS-Protection
+Header always set X-XSS-Protection "1; mode=block"
+Header unset X-Content-Type-Options
+Header always set X-Content-Type-Options: nosniff
+Header unset Strict-Transport-Security
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+Header unset Referrer-Policy
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
+Header unset Cache-Control
+Header always set Cache-Control "max-age=300, no-cache=\"Set-Cookie, Set-Cookie2\""
 
 ProxyTimeout ${PROXY_TIMEOUT}
 LDAPCacheTTL ${LDAP_CACHE_TTL}


### PR DESCRIPTION
All the templated `site.conf.ctmpls` define this -- adding to the default in this repo.