### PR TITLE
[TOAZ-186] Bump liboauth2 to 1.4.5.1 for concurrency fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM broadinstitute/openidc-baseimage:3.0
 ENV MOD_SECURITY_VERSION=2.9.2 \
-    LIBOAUTH2_VERSION=1.4.5 \
+    LIBOAUTH2_VERSION=1.4.5.1 \
     OAUTH2_VERSION=3.2.3
 
 RUN apt-get update && apt-get upgrade -yq && \

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-ENV LIBOAUTH2_VERSION=1.4.5 \
+ENV LIBOAUTH2_VERSION=1.4.5.1 \
     OAUTH2_VERSION=3.2.3
 
 # Install dependencies


### PR DESCRIPTION
https://github.com/zmartzone/liboauth2/releases/tag/v1.4.5.1