### PR TITLE
[DDO-2875] Use SIGWINCH to stop Apache, only use SIGTERM after 25 seconds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,20 +31,20 @@ RUN cd /root && \
     mkdir rulesworking && \
     mkdir rulesfinal && \
     cp -rfp rules/REQUEST-921-PROTOCOL-ATTACK.conf \
-      rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf \
-      rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf \
-      rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf \
-      rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf \
-      rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf \
-      rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf rulesworking/ && \
-      util/join-multiline-rules/join.py rulesworking/*.conf > rulesfinal/rules.conf && \
-      cp -rfp rulesfinal/* /etc/modsecurity && \
-      cp -rfp rules/*.data /etc/modsecurity/
+    rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf \
+    rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf \
+    rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf \
+    rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf \
+    rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf \
+    rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf rulesworking/ && \
+    util/join-multiline-rules/join.py rulesworking/*.conf > rulesfinal/rules.conf && \
+    cp -rfp rulesfinal/* /etc/modsecurity && \
+    cp -rfp rules/*.data /etc/modsecurity/
 
 COPY modsecurity.conf /etc/modsecurity/modsecurity.conf
 COPY unicode.mapping /etc/modsecurity/unicode.mapping
 
-COPY site.conf /etc/apache2/sites-available/
+COPY site.conf graceful_shutdown.conf /etc/apache2/sites-available/
 COPY override.sh /etc/apache2/
 COPY mpm_event.conf /etc/apache2/conf-available/
 RUN a2dismod mpm_prefork && \
@@ -84,3 +84,8 @@ RUN chmod +x /tmp/run-php-fpm.sh && \
     mv /tmp/run-php-fpm.sh /etc/service/php-fpm/run
 
 COPY introspect.php /app/introspect/index.php
+
+# Apache runs graceful stop only upon SIGWINCH. Normal SIGTERM is an immediate stop.
+# GracefulShutdownTimeout directive configured via graceful_shutdown.conf.
+# https://httpd.apache.org/docs/2.4/stopping.html
+STOPSIGNAL SIGWINCH

--- a/Dockerfile.mod_security
+++ b/Dockerfile.mod_security
@@ -27,14 +27,19 @@ RUN cd /root && \
     git clone https://github.com/SpiderLabs/owasp-modsecurity-crs.git && \
     cd owasp-modsecurity-crs && \
     cp -rfp rules/REQUEST-921-PROTOCOL-ATTACK.conf \
-      rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf \
-      rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf \
-      rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf \
-      rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf \
-      rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf \
-      rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf \
-      rules/*.data /etc/modsecurity/
+    rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf \
+    rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf \
+    rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf \
+    rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf \
+    rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf \
+    rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf \
+    rules/*.data /etc/modsecurity/
 
 
-COPY site.conf /etc/apache2/sites-available/
+COPY site.conf graceful_shutdown.conf /etc/apache2/sites-available/
 COPY override.sh /etc/apache2/
+
+# Apache runs graceful stop only upon SIGWINCH. Normal SIGTERM is an immediate stop.
+# GracefulShutdownTimeout directive configured via graceful_shutdown.conf.
+# https://httpd.apache.org/docs/2.4/stopping.html
+STOPSIGNAL SIGWINCH

--- a/Dockerfile.ubi-minimal
+++ b/Dockerfile.ubi-minimal
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV LIBOAUTH2_VERSION=1.4.5.1 \
-    OAUTH2_VERSION=3.2.3
+  OAUTH2_VERSION=3.2.3
 
 # Install dependencies
 RUN microdnf --nodocs -y install \
@@ -22,14 +22,14 @@ RUN microdnf --nodocs -y install \
 # Install hiredis (dependency of liboauth2) from EPEL
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
   && microdnf --nodocs -y install \
-    hiredis-0.13.3-13.el8.x86_64 \
+  hiredis-0.13.3-13.el8.x86_64 \
   && microdnf clean all
 
 # Install tcell module
 RUN mkdir -p /tmp/build && cd /tmp/build \
-   && wget https://us.static.tcell.insight.rapid7.com/downloads/apacheagent/apache24_tcellagent-3.1.0-linux-x86_64.tgz \ 
-   && tar -xzf apache24_tcellagent-3.1.0-linux-x86_64.tgz \
-   && cp -rfp apache_tcellagent-3.1.0-linux-x86_64/centos/mod_agenttcell.so /etc/httpd/modules/mod_agenttcell.so
+  && wget https://us.static.tcell.insight.rapid7.com/downloads/apacheagent/apache24_tcellagent-3.1.0-linux-x86_64.tgz \ 
+  && tar -xzf apache24_tcellagent-3.1.0-linux-x86_64.tgz \
+  && cp -rfp apache_tcellagent-3.1.0-linux-x86_64/centos/mod_agenttcell.so /etc/httpd/modules/mod_agenttcell.so
 
 # Install mod_oauth2 module
 RUN rpm -ivh \
@@ -39,7 +39,7 @@ RUN rpm -ivh \
   https://github.com/zmartzone/mod_oauth2/releases/download/v${OAUTH2_VERSION}/mod_oauth2-${OAUTH2_VERSION}-1.el8.x86_64.rpm
 
 # Copy configs
-COPY site.conf mpm_event.conf oauth2.conf ssl_fips.conf /etc/httpd/conf.d/
+COPY site.conf graceful_shutdown.conf mpm_event.conf oauth2.conf ssl_fips.conf /etc/httpd/conf.d/
 COPY tcell.load /etc/httpd/conf.modules.d/99-tcell.load
 COPY introspect.php /app/introspect/index.php
 COPY run-httpd /usr/bin
@@ -58,5 +58,10 @@ RUN chmod a+x /usr/bin/run-httpd \
 
 EXPOSE 80
 EXPOSE 443
+
+# Apache runs graceful stop only upon SIGWINCH. Normal SIGTERM is an immediate stop.
+# GracefulShutdownTimeout directive configured via graceful_shutdown.conf.
+# https://httpd.apache.org/docs/2.4/stopping.html
+STOPSIGNAL SIGWINCH
 
 CMD php-fpm & /usr/bin/run-httpd

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This container images extends [OpenIDC BaseImage][1] and adds several features:
   * INTROSPECT_PATH: The path to the RFC 7662 introspection endpoint.  Note this must end with a slash. Default: __/introspect/__
   * ENVIRONMENT: The environment that the proxy is running in.  Can be one of the following values: dev, alpha, perf, staging, prod. Default: __dev__
   * ALLOW_EXPRESSION: An [Apache expression!](https://httpd.apache.org/docs/2.4/expr.html) to include for allowing requests.  Note: this check happens *after* the authentication flow so you can access environment oauth variables using epressions like `%{HTTP:OAUTH2_CLAIM_email}`.  Also, it must contain a value (which is why the default is true).  Default: __true__
-  * GRACEFUL_SHUTDOWN_TIMEOUT: The time, in seconds, after a SIGWINCH (graceful stop) to send a SIGTERM (immediate stop) to children. Default __15__
+  * GRACEFUL_SHUTDOWN_TIMEOUT: The time, in seconds, after a SIGWINCH (graceful stop) to send a SIGTERM (immediate stop) to children. Default __25__
 
 [1]: https://github.com/broadinstitute/openidc-baseimage "OpenIDC BaseImage"

--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ This container images extends [OpenIDC BaseImage][1] and adds several features:
   * INTROSPECT_PATH: The path to the RFC 7662 introspection endpoint.  Note this must end with a slash. Default: __/introspect/__
   * ENVIRONMENT: The environment that the proxy is running in.  Can be one of the following values: dev, alpha, perf, staging, prod. Default: __dev__
   * ALLOW_EXPRESSION: An [Apache expression!](https://httpd.apache.org/docs/2.4/expr.html) to include for allowing requests.  Note: this check happens *after* the authentication flow so you can access environment oauth variables using epressions like `%{HTTP:OAUTH2_CLAIM_email}`.  Also, it must contain a value (which is why the default is true).  Default: __true__
+  * GRACEFUL_SHUTDOWN_TIMEOUT: The time, in seconds, after a SIGWINCH (graceful stop) to send a SIGTERM (immediate stop) to children. Default __15__
 
 [1]: https://github.com/broadinstitute/openidc-baseimage "OpenIDC BaseImage"

--- a/graceful_shutdown.conf
+++ b/graceful_shutdown.conf
@@ -1,2 +1,2 @@
-# Default of 15 seconds set via `run-httpd` or `override.sh`
+# Default of 25 seconds set via `run-httpd` or `override.sh`
 GracefulShutdownTimeout ${GRACEFUL_SHUTDOWN_TIMEOUT}

--- a/graceful_shutdown.conf
+++ b/graceful_shutdown.conf
@@ -1,0 +1,2 @@
+# Default of 15 seconds set via `run-httpd` or `override.sh`
+GracefulShutdownTimeout ${GRACEFUL_SHUTDOWN_TIMEOUT}

--- a/override.sh
+++ b/override.sh
@@ -188,7 +188,7 @@ if [ -z "$ALLOW_EXPRESSION" ] ; then
     export ALLOW_EXPRESSION='true'
 fi
 
-# default gaceful shutdown timeout
+# default graceful shutdown timeout
 if [ -z "$GRACEFUL_SHUTDOWN_TIMEOUT"]; then
     export GRACEFUL_SHUTDOWN_TIMEOUT=15
 fi

--- a/override.sh
+++ b/override.sh
@@ -190,6 +190,6 @@ fi
 
 # default graceful shutdown timeout
 if [ -z "$GRACEFUL_SHUTDOWN_TIMEOUT"]; then
-    export GRACEFUL_SHUTDOWN_TIMEOUT=15
+    export GRACEFUL_SHUTDOWN_TIMEOUT=25
 fi
 

--- a/override.sh
+++ b/override.sh
@@ -188,4 +188,8 @@ if [ -z "$ALLOW_EXPRESSION" ] ; then
     export ALLOW_EXPRESSION='true'
 fi
 
+# default gaceful shutdown timeout
+if [ -z "$GRACEFUL_SHUTDOWN_TIMEOUT"]; then
+    export GRACEFUL_SHUTDOWN_TIMEOUT=15
+fi
 

--- a/run-httpd
+++ b/run-httpd
@@ -224,6 +224,11 @@ if [ "$ENABLE_TCELL" = "yes" ]; then
     mv /etc/httpd/conf.modules.d/99-tcell.load /etc/httpd/conf.modules.d/99-tcell.conf
 fi
 
+# default gaceful shutdown timeout
+if [ -z "$GRACEFUL_SHUTDOWN_TIMEOUT"]; then
+    export GRACEFUL_SHUTDOWN_TIMEOUT=15
+fi
+
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/httpd/httpd.pid
 

--- a/run-httpd
+++ b/run-httpd
@@ -224,7 +224,7 @@ if [ "$ENABLE_TCELL" = "yes" ]; then
     mv /etc/httpd/conf.modules.d/99-tcell.load /etc/httpd/conf.modules.d/99-tcell.conf
 fi
 
-# default gaceful shutdown timeout
+# default graceful shutdown timeout
 if [ -z "$GRACEFUL_SHUTDOWN_TIMEOUT"]; then
     export GRACEFUL_SHUTDOWN_TIMEOUT=15
 fi

--- a/run-httpd
+++ b/run-httpd
@@ -226,7 +226,7 @@ fi
 
 # default graceful shutdown timeout
 if [ -z "$GRACEFUL_SHUTDOWN_TIMEOUT"]; then
-    export GRACEFUL_SHUTDOWN_TIMEOUT=15
+    export GRACEFUL_SHUTDOWN_TIMEOUT=25
 fi
 
 # Apache gets grumpy about PID files pre-existing


### PR DESCRIPTION
My vscode insisted on fixing some formatting, sorry.

So there's a Docker directive to configure which signal to send when the container is told to shut down, [STOPSIGNAL](https://docs.docker.com/engine/reference/builder/#stopsignal). [Kubernetes says "many" container runtimes respect this](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination), and those container runtimes are the ones who would choose to send SIGTERM as the default anyway.

Benefit of sending SIGWINCH (yes, that's the non-POSIX signal for [_window size changes_](https://stackoverflow.com/a/32647166)) is that's what Apache uses for [its graceful shutdown behavior](https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop). SIGTERM, meanwhile, [causes an "immediate" exit](https://httpd.apache.org/docs/2.4/stopping.html#term).

Kubernetes will step in eventually (30 seconds by default) and send SIGKILL to anything still running in the container. Rather than going straight from SIGWINCH to SIGKILL, this PR also sets Apache's `GracefulShutdownTimeout` directive to a default of 25 seconds (after which the parent Apache process will send SIGTERM to children). It does so by including another .conf file, so it is additive to whatever configuration we mount in Kubernetes. It's configurable via `GRACEFUL_SHUTDOWN_TIMEOUT` if we need.

[Note that DevOps recently just extended our pod timeout grace period to 60 seconds](https://github.com/broadinstitute/terra-helmfile/pull/4221), up from 30.

## Testing

I swapped beehive-dev over to this proxy version without issue. No matter what I do I can't seem to get `[notice]` messages appearing to verify the signal that apache is receiving, but I'm confident that whatever I'm doing it isn't worse than the current behavior.

> I've spent most of today trying to see `[notice]` logs that Apache is supposed to print upon shutdown. I can't get it. If anyone has ideas I'm happy to hear them. I've tried every combination of ErrorLog and LogLevel and CustomLog etc and I'm never able to see anything like `[notice] caught SIGWINCH, shutting down gracefully`. Since GCP _also_ shuts down networking immediately, we can't actually test that this fixes a user-facing issue.

## Risk

I'll have to update charts to use this. If there's issues I expect we'd see them long before production.

There's some risk to local dev flows here if they use the proxy. Before, ctrl+c on a container would forcibly kill any connections. Now, it'll block for up to 25 seconds trying to gracefully shut down. I... don't really see that as a problem, I think it might be a nudge towards apps/UIs actually handling shut downs properly. I guess what I'm saying is this PR might reveal long-standing issues in our apps that we've been able to ignore so far in our local dev flows. If people really dislike it then their local dev scripts can opt to send SIGTERMs directly, there's a flag for that on the docker CLI.